### PR TITLE
Fix missing link to data carpentry website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ is_production: true
 nhw_site: "https://neurohackweek.github.io"
 nhw_github: "https://github.com/neurohackweek"
 swc_site: "https://software-carpentry.org"
+dc_site: "http://datacarpentry.org"
 template_repo: "https://github.com/swcarpentry/styles"
 example_repo: "https://github.com/swcarpentry/lesson-example"
 example_site: "https://swcarpentry.github.com/lesson-example"


### PR DESCRIPTION
Hi everyone! Thank you for sharing this very nice lesson template! This PR fixes a missing link to the data carpentry website. 

(I am re-using your template at: https://github.com/easyreporting/fmri_reporting).